### PR TITLE
Fix URLs containing the hostname in the path.

### DIFF
--- a/pcap2curl.py
+++ b/pcap2curl.py
@@ -20,10 +20,11 @@ def payload2curl(p):
             host_header = re.search("^Host: (.*)", line)
             host_name = host_header.group(1)
 
-    if host_name not in url:
-        url = "http://{}/{}".format(host_name, url)
-    curl = "curl '{}' \\\n -X {} \\\n".format(url, method)
-    curl += " \\\n".join(headers)
+    proto_host = 'http://{}/'.format(host_name)
+    if not url.startswith(proto_host):
+        url = "{}{}".format(proto_host, url[1:] if url[0] == "/" else url)
+    curl = "curl '{}' \\\n -X {} \\\n ".format(url, method)
+    curl += " \\\n ".join(headers)
     return curl
 
 


### PR DESCRIPTION
When the path of a URL contained the hostname, the full
URL would not be reconstructed properly.  For example:
http://example.org/sites/example.org/test

This now checks if the URL begins with the appropriate protocol & host, instead of just checking if it contains it.